### PR TITLE
Cookie path

### DIFF
--- a/Resources/views/cookie_acknowledgement_bar.html.twig
+++ b/Resources/views/cookie_acknowledgement_bar.html.twig
@@ -19,7 +19,7 @@
         function setCookieAccepted() {
             expiry = new Date();
             expiry.setTime(expiry.getTime()+({{ cookieExpiryTime }} * 1000 * 60 * 60 * 24));
-            document.cookie = "cookie_law_accepted=1; expires=" + expiry.toGMTString();
+            document.cookie = "cookie_law_accepted=1; expires=" + expiry.toGMTString() + "; path=/";
         }
 
         button.onclick = function() {


### PR DESCRIPTION
Accepting bar on example.com/demo is not respected on example.com.
Setting `path=/` is fixing the problem and cookie is present on whole domain.
