### PR TITLE
Symfony 3.* compatibility

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,5 +4,5 @@ parameters:
 
 services:
     xsolve.cookie_acknowledgement_bar.service:
-        class: %xsolve.cookie_acknowledgement_bar.service.class%
-        arguments:    ["@templating", %xsolve.cookie_acknowledgement_bar.template%]
+        class: "%xsolve.cookie_acknowledgement_bar.service.class%"
+        arguments:    ["@templating", "%xsolve.cookie_acknowledgement_bar.template%"]


### PR DESCRIPTION
This will fix deprecation warning on early symfony 3.0 ~3.1 versions and make it compatible when it will be removed.

> Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0
